### PR TITLE
Fix bug with go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/sdcampbell/nmapurls
 
-go 1.21.0
+go 1.21


### PR DESCRIPTION
go.mod:3: invalid go version '1.21.0': must match format 1.23