### PR TITLE
Add HTTPS-only filtering option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Edit: The output now prints hostnames when available. Otherwise it prints an IP 
 
 ## Usage:
 
+### Basic usage:
 ```
 cat nmap.xml | ./nmapurls
 http://192.168.1.1:80
@@ -21,7 +22,7 @@ https://192.168.1.13:443
 ```
 
 ```
-./nmap -f nmap.xml
+./nmapurls -f nmap.xml
 http://192.168.1.1:80
 https://192.168.1.1:443
 http://192.168.1.4:80
@@ -34,6 +35,29 @@ https://192.168.1.7:443
 http://192.168.1.13:80
 https://192.168.1.13:443
 ```
+
+### Extract only HTTPS services:
+```
+./nmapurls -f nmap.xml --https-only
+https://192.168.1.1:443
+https://192.168.1.4:443
+https://192.168.1.6:443
+https://192.168.1.7:443
+https://192.168.1.13:443
+```
+
+```
+./nmapurls -f nmap.xml -s
+https://192.168.1.1:443
+https://192.168.1.4:443
+https://192.168.1.6:443
+https://192.168.1.7:443
+https://192.168.1.13:443
+```
+
+## Options:
+- `-f, --file`: Nmap XML report file path
+- `-s, --https-only`: Extract only HTTPS services
 
 ## Build:
 

--- a/nmapurls.go
+++ b/nmapurls.go
@@ -66,6 +66,8 @@ func parseNmapXML(reader io.Reader) (*NmapRun, error) {
 func main() {
     fileFlag := flag.String("file", "", "Nmap XML report file path")
     flag.StringVar(fileFlag, "f", "", "Nmap XML report file path (shorthand)")
+    httpsOnly := flag.Bool("https-only", false, "Extract only HTTPS services")
+    flag.BoolVar(httpsOnly, "s", false, "Extract only HTTPS services (shorthand)")
     flag.Parse()
 
     var reader io.Reader
@@ -104,6 +106,9 @@ func main() {
 
         for _, port := range host.Ports.Port {
             if port.State.State == "open" && (port.Service.Name == "http" || port.Service.Name == "https") {
+                if *httpsOnly && port.Service.Name != "https" {
+                    continue
+                }
                 protocol := port.Service.Name
                 url := fmt.Sprintf("%s://%s:%d", protocol, address, port.PortID)
                 fmt.Println(url)


### PR DESCRIPTION
- Add --https-only and -s flags to extract only HTTPS services
- Update README with usage examples and options documentation